### PR TITLE
[DNM] Demoing Gatsby Union functionality

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
         resolve: `gatsby-source-contentful`,
         options: {
           spaceId: `p9wvos6zyimj`,
-          accessToken: process.env.CMS_API_KEY
+          accessToken: `7f1a358e5546a3760c910aeb5acb8dbf29f359561d6f4d06a6c02374e700a292`
         }
       }
   ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,7 +8,7 @@ module.exports = {
         resolve: `gatsby-source-contentful`,
         options: {
           spaceId: `p9wvos6zyimj`,
-          accessToken: `7f1a358e5546a3760c910aeb5acb8dbf29f359561d6f4d06a6c02374e700a292`
+          accessToken: process.env.CMS_API_KEY
         }
       }
   ],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -73,7 +73,7 @@ const genAllShapesField = (CircleGql, SquareGql, allNodes) => {
 exports.enhanceSchema = ({ types, allNodes}) => {
   const CircleType = types[`contentfulCircle`].nodeObjectType
   const SqaureType = types[`contentfulSquare`].nodeObjectType
-  console.log('here');
+
   return new Promise((resolve, reject) => {
     const allShapes = genAllShapesField(CircleType, SqaureType, allNodes);
     resolve(allShapes)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -15,7 +15,7 @@ exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
     createNodeField({
       node,
       name: `area`,
-      value: node.sideLength * node.sideLength
+      value: node.sideLength * node.sideLength + 0.01 // hack for the moment to force GQLfloat
     })
   }
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,6 @@
+const _ = require(`lodash`)
+const { GraphQLUnionType, GraphQLList } = require(`graphql`)
+
 const cmsPrefix = `Contentful`
 
 const getCircleArea = radius => {
@@ -23,4 +26,56 @@ exports.onCreateNode = ({ node, boundActionCreators, getNode }) => {
       value: getCircleArea(node.radius)
     })
   }
+}
+
+/**
+ * The GraphQL definition of our shape union type
+ */
+const defineShapesType = (CircleGql, SquareGql) => (
+  new GraphQLUnionType({
+    name: `AllShapesType`,
+    description: `All shapes under one roof`,
+    types: [ CircleGql, SquareGql ],
+    resolveType: (data) => {
+      const { type } = data.internal
+      switch (type) {
+        case `ContentfulCircle`:
+          return CircleGql
+        case `ContentfulSquare`:
+          return SquareGql
+        default:
+          return null
+      }
+    },
+  })
+)
+
+const genAllShapesField = (CircleGql, SquareGql, allNodes) => {
+  return {
+    allShapes: {
+      type: new GraphQLList(defineShapesType(CircleGql, SquareGql)),
+      args: {},
+      resolve(root, args) {
+        const latestNodes = _.filter(
+          allNodes,
+          n => (n.internal.type === `ContentfulCircle`) ||
+                (n.internal.type === `ContentfulSquare`)
+        )
+        return latestNodes
+      },
+    },
+  }
+}
+
+/**
+ * Hook up the Union Query
+ */
+exports.enhanceSchema = ({ types, allNodes}) => {
+  const CircleType = types[`contentfulCircle`].nodeObjectType
+  const SqaureType = types[`contentfulSquare`].nodeObjectType
+  console.log('here');
+  return new Promise((resolve, reject) => {
+    const allShapes = genAllShapesField(CircleType, SqaureType, allNodes);
+    resolve(allShapes)
+  });
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "n/a",
   "scripts": {
     "build": "gatsby build",
-    "develop": "gatsby develop",
+    "develop": "gatsby develop --verbose",
     "format": "prettier --trailing-comma es5 --no-semi --single-quote --write \"src/**/*.js\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -73,24 +73,40 @@ export const query = graphql`
     squares: allContentfulSquare {
       edges {
         node {
-          id
-          sideLength
-          fields {
-            area
-          }
+          ...sqaureFields
         }
       }
     }
     circles: allContentfulCircle {
       edges {
         node {
-          id
-          radius
-          fields {
-            area
-          }
+          ...circleFields
         }
       }
+    }
+    shapes: allShapes {
+      ... on ContentfulCircle {
+        ...circleFields
+      }
+      ... on ContentfulSquare {
+        ...sqaureFields
+      }
+    }
+  }
+
+  fragment circleFields on ContentfulCircle {
+    id
+    radius
+    fields {
+      area
+    }
+  }
+
+  fragment sqaureFields on ContentfulSquare {
+    id
+    sideLength
+    fields {
+      area
     }
   }
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -3070,9 +3070,9 @@ gatsby-1-config-css-modules@^1.0.6:
   dependencies:
     babel-runtime "^6.26.0"
 
-gatsby-cli@^1.1.20:
-  version "1.1.20"
-  resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-1.1.20.tgz#ae63cd3e9c84369f76c4c9d392d4fed580ca02fd"
+gatsby-cli@^1.1.22:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/gatsby-cli/-/gatsby-cli-1.1.22.tgz#5ffef1dda85cde7536d389f333416794ec6a3b01"
   dependencies:
     babel-code-frame "^6.26.0"
     babel-runtime "^6.26.0"
@@ -3099,9 +3099,9 @@ gatsby-link@^1.6.24:
     prop-types "^15.5.8"
     ric "^1.3.0"
 
-gatsby-module-loader@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/gatsby-module-loader/-/gatsby-module-loader-1.0.7.tgz#c103ca41765d21453cc104e77190e491210abc75"
+gatsby-module-loader@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/gatsby-module-loader/-/gatsby-module-loader-1.0.8.tgz#426800c29b9b67cae2b6181317cd300d823e7428"
   dependencies:
     babel-runtime "^6.26.0"
     loader-utils "^0.2.16"
@@ -3119,9 +3119,9 @@ gatsby-plugin-styled-components@^2.0.2:
   dependencies:
     babel-runtime "^6.26.0"
 
-gatsby-react-router-scroll@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-1.0.3.tgz#b4b7850850d078b1816a15abf332c93b4d42e3f1"
+gatsby-react-router-scroll@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-1.0.5.tgz#377b03e0320866f40b6c2234d38b19d1b035c353"
   dependencies:
     babel-runtime "^6.26.0"
     scroll-behavior "^0.9.1"
@@ -3143,8 +3143,8 @@ gatsby-source-contentful@^1.3.22:
     qs "^6.4.0"
 
 gatsby@^1.9.102:
-  version "1.9.106"
-  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-1.9.106.tgz#1a16eedc5c19b48b49a3722df81afbd84af01d9c"
+  version "1.9.118"
+  resolved "https://registry.yarnpkg.com/gatsby/-/gatsby-1.9.118.tgz#76d94faaa91f0ebe39fd2346f91a26146bff4009"
   dependencies:
     async "^2.1.2"
     babel-code-frame "^6.22.0"
@@ -3183,9 +3183,9 @@ gatsby@^1.9.102:
     front-matter "^2.1.0"
     fs-extra "^4.0.1"
     gatsby-1-config-css-modules "^1.0.6"
-    gatsby-cli "^1.1.20"
-    gatsby-module-loader "^1.0.7"
-    gatsby-react-router-scroll "^1.0.3"
+    gatsby-cli "^1.1.22"
+    gatsby-module-loader "^1.0.8"
+    gatsby-react-router-scroll "^1.0.5"
     glob "^7.1.1"
     graphql "^0.11.7"
     graphql-relay "^0.5.1"
@@ -3194,7 +3194,7 @@ gatsby@^1.9.102:
     invariant "^2.2.2"
     is-relative "^0.2.1"
     is-relative-url "^2.0.0"
-    joi "^9.1.1"
+    joi "12.x.x"
     json-loader "^0.5.2"
     json-stringify-safe "^5.0.1"
     json5 "^0.5.0"
@@ -4083,6 +4083,12 @@ isemail@2.x.x:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
 
+isemail@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.0.0.tgz#c89a46bb7a3361e1759f8028f9082488ecce3dff"
+  dependencies:
+    punycode "2.x.x"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -4120,19 +4126,17 @@ iterall@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
+joi@12.x.x:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
+  dependencies:
+    hoek "4.x.x"
+    isemail "3.x.x"
+    topo "2.x.x"
+
 joi@9.0.0-0:
   version "9.0.0-0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-9.0.0-0.tgz#a7ca4219602149ae0da7a7c5ca1d63d3c79e096b"
-  dependencies:
-    hoek "4.x.x"
-    isemail "2.x.x"
-    items "2.x.x"
-    moment "2.x.x"
-    topo "2.x.x"
-
-joi@^9.1.1:
-  version "9.2.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-9.2.0.tgz#3385ac790192130cbe230e802ec02c9215bbfeda"
   dependencies:
     hoek "4.x.x"
     isemail "2.x.x"
@@ -6019,6 +6023,10 @@ pump@^1.0.0:
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
+
+punycode@2.x.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
 
 punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
This site is a simple visual list of sqaures and circles for the purpose of spiking some gatsby union functionality type stuff. This PR uses a proposed extension API on gatsby to specify a GrapqlUnion allowing the user to query (and in future sort, filter, page) multiple types at the same time, which would be dreamy.

CMS is contentful and it has some squares and some circles. Squares have a sideLength and Circles have a radius. Area is calculated locally and added to nodes using `onCreateNode` API

- Ignore filtering, paging, sorting (can worry about that later)
- Raising to get early feedback


Credit to Clay Allsopp for this article which was a big help https://medium.com/the-graphqlhub/graphql-tour-interfaces-and-unions-7dd5be35de0d